### PR TITLE
fix undefined value from env

### DIFF
--- a/api/index.js
+++ b/api/index.js
@@ -2,6 +2,7 @@ const express = require("express");
 const app = express();
 const mongoose = require("mongoose");
 const dotenv = require("dotenv");
+dotenv.config();
 const userRoute = require("./routes/user");
 const authRoute = require("./routes/auth");
 const productRoute = require("./routes/product");
@@ -10,7 +11,6 @@ const orderRoute = require("./routes/order");
 const stripeRoute = require("./routes/stripe");
 const cors = require("cors");
 
-dotenv.config();
 
 mongoose
   .connect(process.env.MONGO_URL)

--- a/api/routes/stripe.js
+++ b/api/routes/stripe.js
@@ -1,5 +1,5 @@
 const router = require("express").Router();
-const stripe = require("stripe")("sk_test_51JXYIiLUkaywcbNzmYFRFv00kqiCt8e1Y18wsijxn1mIgkc2ZPW11KxRd1i00v5B4cbfFBvaLgjEsT8on2daVzhG00zIvUj5z7");
+const stripe = require("stripe")(process.env.STRIPE_KEY);
 
 router.post("/payment", (req, res) => {
   stripe.charges.create(


### PR DESCRIPTION
Previously I had a problem to read enviroment from `.env` file by calling `process.env.STRIPE_KEY`. 

but now there is no problem with it, I moved line `dotenv.config()` before import routes. So now I don't need to write the secret code from stripe directly in my line of code, but I can call the secret key from `.env`